### PR TITLE
More address tests

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -58,12 +58,14 @@ function errorCodeToString(statusCode) {
 }
 
 export default class LedgerApp {
-  constructor(transport, scrambleKey = APP_KEY) {
-    if (typeof transport === "undefined") {
+  constructor(transport) {
+    if (!transport) {
       throw new Error("Transport has not been defined");
     }
 
     this.transport = transport;
+
+    const scrambleKey = APP_KEY;
     transport.decorateAppAPIMethods(this, ["getVersion", "getAddress", "sign"], scrambleKey);
   }
 

--- a/tests/basic.ispec.js
+++ b/tests/basic.ispec.js
@@ -50,6 +50,39 @@ describe("Integration tests", () => {
     }
   });
 
+  test("get multiple addresses", async () => {
+    const app = new LedgerApp(transport);
+    const version = await app.getVersion();
+
+    const response0 = await app.getAddress(harden(0));
+    const response1 = await app.getAddress(harden(1));
+    const response2 = await app.getAddress(harden(2));
+    const response3 = await app.getAddress(harden(3));
+    const response4 = await app.getAddress(harden(4));
+
+    // Calculated using Token Finder tool with mnemonic
+    // equip will roof matter pink blind book anxiety banner elbow sun young
+    expect(response0.pubKey).toEqual("5fe68efa9e7e6373a51f6e519b4ffc7d6330c6cd011d00f6a9663ca82c361bff");
+    expect(response1.pubKey).toEqual("385fe5a946e46727297cf7ad0bff7efa637e1c7516ea2fd9f6dc717404494455");
+    expect(response2.pubKey).toEqual("c8dca85dd7f1c4f231e46d579199b310975379c37445c664d1be824f088dbe07");
+    expect(response3.pubKey).toEqual("5ad1501134fb4ba2f5b1d7c8ca539152d7c31f07a301f6192bb757b3dab52a88");
+    expect(response4.pubKey).toEqual("f10ea4323ac84582370321208c71ca77700c85a099991aefc153bc5284c9c025");
+
+    if (version.test_mode) {
+      expect(response0.address).toEqual("tiov1l678408y7a64cj66s8j64fevmspyfxdmv38cxw");
+      expect(response1.address).toEqual("tiov1u42wk6lk009ex9t87gt54sn24m2psl4axfrd28");
+      expect(response2.address).toEqual("tiov1lxry06n8l760mkthg7sgda48cne4t26llzwntz");
+      expect(response3.address).toEqual("tiov10ur3vxhy00el95g5fqthe889z6lzqgr0f63tnl");
+      expect(response4.address).toEqual("tiov12evzw2nds3qzfdrlnka5hx25azaarh3qypr6uv");
+    } else {
+      expect(response0.address).toEqual("iov1l678408y7a64cj66s8j64fevmspyfxdmzywuxl");
+      expect(response1.address).toEqual("iov1u42wk6lk009ex9t87gt54sn24m2psl4agu2f2k");
+      expect(response2.address).toEqual("iov1lxry06n8l760mkthg7sgda48cne4t26l3h8htn");
+      expect(response3.address).toEqual("iov10ur3vxhy00el95g5fqthe889z6lzqgr080c0nw");
+      expect(response4.address).toEqual("iov12evzw2nds3qzfdrlnka5hx25azaarh3q2527ua");
+    }
+  });
+
   test("show address", async () => {
     jest.setTimeout(60000);
 

--- a/tests/basic.ispec.js
+++ b/tests/basic.ispec.js
@@ -25,7 +25,7 @@ describe("Integration tests", () => {
     expect(version).toEqual(
       expect.objectContaining({
         major: 0,
-        minor: 7,
+        minor: 8,
         patch: 0,
         device_locked: false,
         error_message: "No errors",


### PR DESCRIPTION
Updated version of #9. It now shows nicely how derived keypairs are the sme for main/test but the addresses are different.